### PR TITLE
convivial-demo-32645: Fixed - InvalidArgumentException: You must provide the context IDs in the @{service_id}:{unqualified_context_id} format.

### DIFF
--- a/config/install/block.block.help_article.yml
+++ b/config/install/block.block.help_article.yml
@@ -27,6 +27,6 @@ visibility:
     id: 'entity_bundle:node'
     negate: false
     context_mapping:
-      node: node
+      node: '@node.node_route_context:node'
     bundles:
       article: article

--- a/config/install/block.block.help_audience.yml
+++ b/config/install/block.block.help_audience.yml
@@ -27,6 +27,6 @@ visibility:
     id: 'entity_bundle:node'
     negate: false
     context_mapping:
-      node: node
+      node: '@node.node_route_context:node'
     bundles:
       audience: audience

--- a/config/install/block.block.help_event.yml
+++ b/config/install/block.block.help_event.yml
@@ -27,6 +27,6 @@ visibility:
     id: 'entity_bundle:node'
     negate: false
     context_mapping:
-      node: node
+      node: '@node.node_route_context:node'
     bundles:
       event: event

--- a/config/install/block.block.help_topic.yml
+++ b/config/install/block.block.help_topic.yml
@@ -27,6 +27,6 @@ visibility:
     id: 'entity_bundle:node'
     negate: false
     context_mapping:
-      node: node
+      node: '@node.node_route_context:node'
     bundles:
       topic: topic

--- a/config/install/block.block.recombee_node_recommendations.yml
+++ b/config/install/block.block.recombee_node_recommendations.yml
@@ -27,7 +27,7 @@ visibility:
     id: 'entity_bundle:node'
     negate: false
     context_mapping:
-      node: node
+      node: '@node.node_route_context:node'
     bundles:
       article: article
       casestudy: casestudy

--- a/config/install/convivial_profiler.settings.yml
+++ b/config/install/convivial_profiler.settings.yml
@@ -1039,7 +1039,7 @@ visibility:
     id: 'entity_bundle:node'
     negate: false
     context_mapping:
-      node: node
+      node: '@node.node_route_context:node'
     bundles: {  }
   request_path:
     id: request_path


### PR DESCRIPTION

Mirrored from morpht/convivial-demo 32645-hotfix @ 10aa978.