### PR TITLE
convivial-29725: Remove the reference of color_field module.

### DIFF
--- a/convivial.info.yml
+++ b/convivial.info.yml
@@ -26,7 +26,6 @@ install:
   - convivial_layouts
   - convivial_profiler
   - convivial_theme_default_render
-  - color_field
   - crop
   - ctools
   - ctools_block


### PR DESCRIPTION
Mirrored from morpht/convivial-demo convivial-29725 @ f5377fd.