### PR TITLE
convivial-34649: Remove email ID from Convivial Profile and site config.

### DIFF
--- a/config/install/system.site.yml
+++ b/config/install/system.site.yml
@@ -1,6 +1,5 @@
 langcode: en
 name: 'Convivial Demo'
-mail: convivial-demo.noreply@pantheon-email.morpht.net
 slogan: ''
 page:
   403: ''


### PR DESCRIPTION
Mirrored from morpht/convivial-demo@6d0f4dfa (34649).