### PR TITLE
convivial-demo-37183: Convivial Profiler: Tops destination

### DIFF
--- a/config/install/block.block.personified_data_audience.yml
+++ b/config/install/block.block.personified_data_audience.yml
@@ -23,5 +23,5 @@ settings:
       source_type: local_storage
       source_key: audience
       endpoint_key: key
-      default_value: 'audience:none'
+      default_value: audience-none
 visibility: {  }

--- a/config/install/block.block.personified_data_experience.yml
+++ b/config/install/block.block.personified_data_experience.yml
@@ -24,7 +24,7 @@ settings:
       source_type: local_storage
       source_key: experience
       endpoint_key: key
-      default_value: 'experience:none'
+      default_value: experience-none
 visibility:
   request_path:
     id: request_path

--- a/config/install/block.block.personified_data_stage.yml
+++ b/config/install/block.block.personified_data_stage.yml
@@ -28,5 +28,5 @@ settings:
       source_type: local_storage
       source_key: stage
       endpoint_key: key
-      default_value: 'stage:orientation'
+      default_value: stage-orientation
 visibility: {  }

--- a/config/install/convivial_profiler.settings.yml
+++ b/config/install/convivial_profiler.settings.yml
@@ -518,6 +518,16 @@ profilers:
         target_location:
           localstorage: localstorage
           cookie: '0'
+      -
+        type: tops
+        target_key: topic_tops
+        dimension_key: dimensions.topic
+        default_value: 'topic-sci-fi,topic-comedic-fiction'
+        stringify: true
+        target_location:
+          localstorage: localstorage
+          cookie: '0'
+        length: 2
   topic_param:
     name: topic_param
     label: 'Topic param'

--- a/config/install/easy_breadcrumb.settings.yml
+++ b/config/install/easy_breadcrumb.settings.yml
@@ -32,3 +32,4 @@ capitalizator_forced_words: {  }
 capitalizator_forced_words_case_sensitivity: true
 capitalizator_forced_words_first_letter: false
 follow_redirects: true
+segment_display_minimum: 1

--- a/config/install/views.view.data_nodes.yml
+++ b/config/install/views.view.data_nodes.yml
@@ -380,45 +380,7 @@ display:
             field_identifier: ''
           exposed: false
           granularity: second
-      arguments:
-        nid:
-          id: nid
-          table: node_field_data
-          field: nid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: node
-          entity_field: nid
-          plugin_id: node_nid
-          default_action: default
-          exception:
-            value: all
-            title_enable: false
-            title: All
-          title_enable: false
-          title: ''
-          default_argument_type: query_parameter
-          default_argument_options:
-            query_param: id
-            fallback: ''
-            multiple: or
-          summary_options:
-            base_path: ''
-            count: true
-            override: false
-            items_per_page: 25
-          summary:
-            sort_order: asc
-            number_of_records: 0
-            format: default_summary
-          specify_validation: false
-          validate:
-            type: none
-            fail: 'not found'
-          validate_options: {  }
-          break_phrase: true
-          not: false
+      arguments: {  }
       filters:
         status:
           id: status
@@ -460,7 +422,6 @@ display:
         - 'languages:language_content'
         - 'languages:language_interface'
         - request_format
-        - url
         - url.query_args
         - 'user.node_grants:view'
         - user.permissions
@@ -468,8 +429,8 @@ display:
         - 'config:field.storage.node.field_body'
         - 'config:field.storage.node.field_published'
         - 'config:field.storage.node.field_thumbnail'
-  nodes_by_key:
-    id: nodes_by_key
+  nodes_by_id:
+    id: nodes_by_id
     display_title: 'Nodes by ID'
     display_plugin: rest_export
     position: 1
@@ -479,6 +440,45 @@ display:
         options:
           offset: 0
           items_per_page: 3
+      arguments:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: node_nid
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: query_parameter
+          default_argument_options:
+            query_param: id
+            fallback: ''
+            multiple: or
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: true
+          not: false
       style:
         type: serializer
         options:
@@ -503,9 +503,105 @@ display:
             field_published:
               alias: date
               raw_output: false
+      defaults:
+        arguments: false
       display_description: ''
       display_extenders: {  }
       path: data/nodes-by-id
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - request_format
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_body'
+        - 'config:field.storage.node.field_published'
+        - 'config:field.storage.node.field_thumbnail'
+  nodes_by_key:
+    id: nodes_by_key
+    display_title: 'Nodes by key'
+    display_plugin: rest_export
+    position: 1
+    display_options:
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 3
+      arguments:
+        field_key_value:
+          id: field_key_value
+          table: node__field_key
+          field: field_key_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: string
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: query_parameter
+          default_argument_options:
+            query_param: key
+            fallback: ''
+            multiple: or
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: false
+          limit: 0
+          case: none
+          path_case: none
+          transform_dash: false
+          break_phrase: true
+      style:
+        type: serializer
+        options:
+          formats:
+            json: json
+      row:
+        type: data_field
+        options:
+          field_options:
+            title:
+              alias: title
+              raw_output: false
+            field_body:
+              alias: body
+              raw_output: false
+            type:
+              alias: type
+              raw_output: false
+            field_thumbnail:
+              alias: image
+              raw_output: false
+            field_published:
+              alias: date
+              raw_output: false
+      defaults:
+        arguments: false
+      display_description: ''
+      display_extenders: {  }
+      path: data/nodes-by-key
     cache_metadata:
       max-age: -1
       contexts:


### PR DESCRIPTION
```
+--------------------------------+--------+--------+
| Production Changes             | From   | To     |
+--------------------------------+--------+--------+
| drupal/easy_breadcrumb         | 2.0.6  | 2.0.7  |
| drupal/field_formatter_pattern | 1.0.1  | 1.0.2  |
| drupal/geofield_map            | 3.0.15 | 3.0.18 |
| drupal/real_aes                | 2.5.0  | 2.6.0  |
| drupal/replicate               | 1.2.0  | 1.3.0  |
| drupal/search_api_recombee     | 4.0.7  | 4.0.8  |
| drupal/stage_file_proxy        | 2.1.4  | 2.1.5  |
| drupal/webform                 | 6.2.2  | 6.2.3  |
| nikic/php-parser               | v5.0.2 | v5.1.0 |
| phpstan/phpstan                | 1.11.5 | 1.11.6 |
| symfony/console                | v6.4.8 | v6.4.9 |
| symfony/dependency-injection   | v6.4.8 | v6.4.9 |
| symfony/error-handler          | v6.4.8 | v6.4.9 |
| symfony/filesystem             | v6.4.8 | v6.4.9 |
| symfony/http-kernel            | v6.4.8 | v6.4.9 |
| symfony/mailer                 | v6.4.8 | v6.4.9 |
| symfony/mime                   | v6.4.8 | v6.4.9 |
| symfony/serializer             | v6.4.8 | v6.4.9 |
| symfony/string                 | v6.4.8 | v6.4.9 |
| symfony/validator              | v6.4.8 | v6.4.9 |
| symfony/var-dumper             | v6.4.8 | v6.4.9 |
| symfony/var-exporter           | v6.4.8 | v6.4.9 |
| webflo/drupal-finder           | 1.3.0  | 1.3.1  |
+--------------------------------+--------+--------+

+------------------------------------+----------+----------+
| Dev Changes                        | From     | To       |
+------------------------------------+----------+----------+
| sirbrillig/phpcs-variable-analysis | v2.11.18 | v2.11.19 |
+------------------------------------+----------+----------+
```

Mirrored from (c-37183).